### PR TITLE
Remove --skip-refresh option from scripts/update-charts-dep.sh script

### DIFF
--- a/scripts/update-charts-dep.sh
+++ b/scripts/update-charts-dep.sh
@@ -41,7 +41,7 @@ echo "Updating all Charts..."
 for chart in "${charts[@]}"
 do
     echo "---=== Updating $chart ===---"
-    helm dep up "$chart" --skip-refresh
+    helm dep up "$chart"
 done
 
 set +x


### PR DESCRIPTION
Helm is failing to download dependencies from external chart repos with this option specified, so we need to remove it.
One of such dependencies is reporting templates helm chart, which is included as a dependency for reporting service.
Removing this option shouldn't affect anything, as it is probably used for optimization purposes only.