### PR TITLE
fix: helm upgrade not working

### DIFF
--- a/mojaloop/admin-api-svc/templates/deployment.yaml
+++ b/mojaloop/admin-api-svc/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ template "common.names.chart" . }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       annotations: 
@@ -28,7 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ template "common.names.chart" . }}
+        app.kubernetes.io/component: {{ .Chart.Name }}
         app.kubernetes.io/version: {{ .Chart.Version }}
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}

--- a/mojaloop/admin-api-svc/templates/ingress.yaml
+++ b/mojaloop/admin-api-svc/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/mojaloop/admin-api-svc/templates/service.yaml
+++ b/mojaloop/admin-api-svc/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -34,4 +34,4 @@ spec:
       protocol: TCP
   {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}

--- a/mojaloop/fspiop-transfer-api-svc/templates/deployment.yaml
+++ b/mojaloop/fspiop-transfer-api-svc/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ template "common.names.chart" . }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       annotations: 
@@ -28,7 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ template "common.names.chart" . }}
+        app.kubernetes.io/component: {{ .Chart.Name }}
         app.kubernetes.io/version: {{ .Chart.Version }}
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}

--- a/mojaloop/fspiop-transfer-api-svc/templates/ingress.yaml
+++ b/mojaloop/fspiop-transfer-api-svc/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/mojaloop/fspiop-transfer-api-svc/templates/service.yaml
+++ b/mojaloop/fspiop-transfer-api-svc/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -34,4 +34,4 @@ spec:
       protocol: TCP
   {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}

--- a/mojaloop/reporting-events-processor-svc/templates/deployment.yaml
+++ b/mojaloop/reporting-events-processor-svc/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ template "common.names.chart" . }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       annotations:
@@ -24,7 +24,7 @@ spec:
       {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ template "common.names.chart" . }}
+        app.kubernetes.io/component: {{ .Chart.Name }}
         app.kubernetes.io/version: {{ .Chart.Version }}
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}

--- a/mojaloop/reporting-hub-bop-api-svc/templates/deployment.yaml
+++ b/mojaloop/reporting-hub-bop-api-svc/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ template "common.names.chart" . }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       annotations:
@@ -28,7 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ template "common.names.chart" . }}
+        app.kubernetes.io/component: {{ .Chart.Name }}
         app.kubernetes.io/version: {{ .Chart.Version }}
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}

--- a/mojaloop/reporting-hub-bop-api-svc/templates/ingress.yaml
+++ b/mojaloop/reporting-hub-bop-api-svc/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/mojaloop/reporting-hub-bop-api-svc/templates/service.yaml
+++ b/mojaloop/reporting-hub-bop-api-svc/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -34,4 +34,4 @@ spec:
       protocol: TCP
   {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}

--- a/mojaloop/reporting-hub-bop-positions-ui/templates/deployment.yaml
+++ b/mojaloop/reporting-hub-bop-positions-ui/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ template "common.names.chart" . }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       annotations:
@@ -28,7 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ template "common.names.chart" . }}
+        app.kubernetes.io/component: {{ .Chart.Name }}
         app.kubernetes.io/version: {{ .Chart.Version }}
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}

--- a/mojaloop/reporting-hub-bop-positions-ui/templates/ingress.yaml
+++ b/mojaloop/reporting-hub-bop-positions-ui/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/mojaloop/reporting-hub-bop-positions-ui/templates/service.yaml
+++ b/mojaloop/reporting-hub-bop-positions-ui/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -34,4 +34,4 @@ spec:
       protocol: TCP
   {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}

--- a/mojaloop/reporting-hub-bop-role-ui/templates/deployment.yaml
+++ b/mojaloop/reporting-hub-bop-role-ui/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ template "common.names.chart" . }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       annotations:
@@ -28,7 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ template "common.names.chart" . }}
+        app.kubernetes.io/component: {{ .Chart.Name }}
         app.kubernetes.io/version: {{ .Chart.Version }}
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}

--- a/mojaloop/reporting-hub-bop-role-ui/templates/ingress.yaml
+++ b/mojaloop/reporting-hub-bop-role-ui/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/mojaloop/reporting-hub-bop-role-ui/templates/service.yaml
+++ b/mojaloop/reporting-hub-bop-role-ui/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -34,4 +34,4 @@ spec:
       protocol: TCP
   {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}

--- a/mojaloop/reporting-hub-bop-settlements-ui/templates/deployment.yaml
+++ b/mojaloop/reporting-hub-bop-settlements-ui/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ template "common.names.chart" . }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       annotations:
@@ -28,7 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ template "common.names.chart" . }}
+        app.kubernetes.io/component: {{ .Chart.Name }}
         app.kubernetes.io/version: {{ .Chart.Version }}
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}

--- a/mojaloop/reporting-hub-bop-settlements-ui/templates/ingress.yaml
+++ b/mojaloop/reporting-hub-bop-settlements-ui/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/mojaloop/reporting-hub-bop-settlements-ui/templates/service.yaml
+++ b/mojaloop/reporting-hub-bop-settlements-ui/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -34,4 +34,4 @@ spec:
       protocol: TCP
   {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}

--- a/mojaloop/reporting-hub-bop-shell/templates/deployment.yaml
+++ b/mojaloop/reporting-hub-bop-shell/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ template "common.names.chart" . }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       annotations: 
@@ -28,7 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ template "common.names.chart" . }}
+        app.kubernetes.io/component: {{ .Chart.Name }}
         app.kubernetes.io/version: {{ .Chart.Version }}
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}

--- a/mojaloop/reporting-hub-bop-shell/templates/ingress.yaml
+++ b/mojaloop/reporting-hub-bop-shell/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/mojaloop/reporting-hub-bop-shell/templates/service.yaml
+++ b/mojaloop/reporting-hub-bop-shell/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -34,4 +34,4 @@ spec:
       protocol: TCP
   {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}

--- a/mojaloop/reporting-hub-bop-trx-ui/templates/deployment.yaml
+++ b/mojaloop/reporting-hub-bop-trx-ui/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ template "common.names.chart" . }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       annotations:
@@ -28,7 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ template "common.names.chart" . }}
+        app.kubernetes.io/component: {{ .Chart.Name }}
         app.kubernetes.io/version: {{ .Chart.Version }}
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}

--- a/mojaloop/reporting-hub-bop-trx-ui/templates/ingress.yaml
+++ b/mojaloop/reporting-hub-bop-trx-ui/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/mojaloop/reporting-hub-bop-trx-ui/templates/service.yaml
+++ b/mojaloop/reporting-hub-bop-trx-ui/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -34,4 +34,4 @@ spec:
       protocol: TCP
   {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}

--- a/mojaloop/reporting-legacy-api/templates/deployment.yaml
+++ b/mojaloop/reporting-legacy-api/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ template "common.names.chart" . }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       annotations:
@@ -28,7 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ template "common.names.chart" . }}
+        app.kubernetes.io/component: {{ .Chart.Name }}
         app.kubernetes.io/version: {{ .Chart.Version }}
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}

--- a/mojaloop/reporting-legacy-api/templates/ingress.yaml
+++ b/mojaloop/reporting-legacy-api/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/mojaloop/reporting-legacy-api/templates/service.yaml
+++ b/mojaloop/reporting-legacy-api/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -34,4 +34,4 @@ spec:
       protocol: TCP
   {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}

--- a/mojaloop/role-assignment-service/templates/deployment.yaml
+++ b/mojaloop/role-assignment-service/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ template "common.names.chart" . }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       annotations: 
@@ -28,7 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ template "common.names.chart" . }}
+        app.kubernetes.io/component: {{ .Chart.Name }}
         app.kubernetes.io/version: {{ .Chart.Version }}
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}

--- a/mojaloop/role-assignment-service/templates/ingress.yaml
+++ b/mojaloop/role-assignment-service/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/mojaloop/role-assignment-service/templates/service.yaml
+++ b/mojaloop/role-assignment-service/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -34,4 +34,4 @@ spec:
       protocol: TCP
   {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}

--- a/mojaloop/security-hub-bop-kratos-ui/templates/deployment.yaml
+++ b/mojaloop/security-hub-bop-kratos-ui/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ template "common.names.chart" . }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       annotations: 
@@ -28,7 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ template "common.names.chart" . }}
+        app.kubernetes.io/component: {{ .Chart.Name }}
         app.kubernetes.io/version: {{ .Chart.Version }}
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}

--- a/mojaloop/security-hub-bop-kratos-ui/templates/ingress.yaml
+++ b/mojaloop/security-hub-bop-kratos-ui/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/mojaloop/security-hub-bop-kratos-ui/templates/service.yaml
+++ b/mojaloop/security-hub-bop-kratos-ui/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -34,4 +34,4 @@ spec:
       protocol: TCP
   {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}

--- a/mojaloop/security-role-perm-operator-svc/templates/deployment.yaml
+++ b/mojaloop/security-role-perm-operator-svc/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "common.names.chart" . }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ template "common.names.chart" . }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       annotations: 
@@ -28,7 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ template "common.names.chart" . }}
+        app.kubernetes.io/component: {{ .Chart.Name }}
         app.kubernetes.io/version: {{ .Chart.Version }}
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}


### PR DESCRIPTION
As the label app.kubernetes.io/component is set with chart name and version, helm upgrade is being failed if the chart version changes.
Changed the value of that from {{ template "common.names.chart" . }} to {{ .Chart.name }} to not include version number