### PR TITLE
fix(mojaloop/#2815): helm chart repo updates are failing due to bitnami's retention policy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,8 @@ defaults_Environment: &defaults_environment
   command: |
     echo "Adding repos necessary for publishing process"
     helm repo add bitnami https://charts.bitnami.com/bitnami
+    ## The following repo is a Work-around for Bitnami retention policy issue: https://github.com/bitnami/charts/issues/10539
+    helm repo add bitnami-full-index https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     helm repo add ory https://k8s.ory.sh/helm/charts
     helm repo add kowl https://raw.githubusercontent.com/cloudhut/charts/master/archives
     helm repo add reporting-k8s-templates https://mojaloop.github.io/reporting-k8s-templates

--- a/README.md
+++ b/README.md
@@ -104,8 +104,6 @@ $ curl http://admin-api-svc.local/participants/Hub/accounts -s | jq
 ]
 ```
 
-  -H 'date: Mon, 20 Sep 2021 11:47:45 GMT'
- 
 ```bash
 $ DATE_ISO=$(date -u +%a,\ %d\ %b\ %Y\ %H:%M:%S\ GMT) && curl -v 'http://transfer-api-svc.local/transfers' \
 -H 'content-type: application/vnd.interoperability.transfers+json;version=1.0' \
@@ -154,10 +152,33 @@ $ DATE_ISO=$(date -u +%a,\ %d\ %b\ %Y\ %H:%M:%S\ GMT) && curl -v 'http://transfe
 * Closing connection 0
 ```
 
+## Running Locally
 
-## Debugging CI/CD
+This can be useful for debugging CI/CD issues.
 
-### Running Locally
+### Pre-requisites
+
+1. Make sure you run the following commands to add all Repo dependencies...
+
+    ```bash
+    helm repo add bitnami https://charts.bitnami.com/bitnami
+    ## The following repo is a Work-around for Bitnami retention policy issue: https://github.com/bitnami/charts/issues/10539, fix: https://github.com/mojaloop/project/issues/2815
+    helm repo add bitnami-full-index https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+    helm repo add ory https://k8s.ory.sh/helm/charts
+    helm repo add kowl https://raw.githubusercontent.com/cloudhut/charts/master/archives
+    helm repo add reporting-k8s-templates https://mojaloop.github.io/reporting-k8s-templates
+    helm repo update
+    ```
+
+2. Run the following commands to update the full helm dependency tree...
+
+    > _Note: Ensure you do this after making any changes to default values or templates._
+
+    ```bash
+    sh ./scripts/update-charts-dep.sh
+    ```
+
+### Running
 
 You can run the `k8s-version-test.sh` script locally to help verify your deployment.
 
@@ -169,23 +190,22 @@ For example:
 sudo CHARTS_WORKING_DIR=`pwd` ./scripts/k8s-versions-test.sh \
   -m install -v v1.21 -u `whoami` -t 1000s
 
-
 ```
 
-> Note: this currently doesn't work on m1 Macs! The MYSQL docker container doesn't have 
+> Note: this currently doesn't work on m1 Macs! The MYSQL docker container doesn't have
 > support for arm64 architectures
 
 ### Check the k8s event logs
 
 When a build fails, we write the k8s events to a log and store it as an artifact on circleci:
 
-```            
+```bash
 kubectl get events --sort-by=.metadata.creationTimestamp > /tmp/k8s_events
 ```
 
 You can check the output of this log to determine if the error is related to pods not starting etc.
 
-### Log in, and get pods:
+### Log in, and get pods
 
 On CircleCI, click "Rerun job with ssh" > Copy and paste the `ssh` command into your command line
 

--- a/mojaloop/example-backend/Chart.yaml
+++ b/mojaloop/example-backend/Chart.yaml
@@ -26,7 +26,10 @@ dependencies:
   - name: kafka
     alias: kafka
     condition: kafka.enabled
-    repository: "https://charts.bitnami.com/bitnami"
+    ## TODO: Update charts to supported versions
+    # repository: "https://charts.bitnami.com/bitnami"
+    ## The following repo is a Work-around for Bitnami retention policy issue (https://github.com/bitnami/charts/issues/10539). Fix: https://github.com/mojaloop/project/issues/2815
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     tags:
       - mojaloop
       - dependency
@@ -36,7 +39,10 @@ dependencies:
   - name: mysql
     alias: mysql
     condition: mysql.enabled
-    repository: "https://charts.bitnami.com/bitnami"
+    ## TODO: Update charts to supported versions
+    # repository: "https://charts.bitnami.com/bitnami"
+    ## The following repo is a Work-around for Bitnami retention policy issue (https://github.com/bitnami/charts/issues/10539). Fix: https://github.com/mojaloop/project/issues/2815
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     tags:
       - mojaloop
       - dependency
@@ -46,7 +52,10 @@ dependencies:
   - name: mongodb
     alias: reporting-events-db
     condition: reporting-events-db.enabled
-    repository: "https://charts.bitnami.com/bitnami"
+    ## TODO: Update charts to supported versions
+    # repository: "https://charts.bitnami.com/bitnami"
+    ## The following repo is a Work-around for Bitnami retention policy issue (https://github.com/bitnami/charts/issues/10539). Fix: https://github.com/mojaloop/project/issues/2815
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     tags:
       - mojaloop
       - dependency
@@ -78,7 +87,10 @@ dependencies:
   - name: mysql
     alias: keto-db
     condition: keto-db.enabled
-    repository: "https://charts.bitnami.com/bitnami"
+    ## TODO: Update charts to supported versions
+    # repository: "https://charts.bitnami.com/bitnami"
+    ## The following repo is a Work-around for Bitnami retention policy issue (https://github.com/bitnami/charts/issues/10539). Fix: https://github.com/mojaloop/project/issues/2815
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     tags:
       - mojaloop
       - dependency
@@ -112,7 +124,10 @@ dependencies:
   - name: mysql
     alias: kratos-db
     condition: kratos-db.enabled
-    repository: "https://charts.bitnami.com/bitnami"
+    ## TODO: Update charts to supported versions
+    # repository: "https://charts.bitnami.com/bitnami"
+    ## The following repo is a Work-around for Bitnami retention policy issue (https://github.com/bitnami/charts/issues/10539). Fix: https://github.com/mojaloop/project/issues/2815
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     tags:
       - mojaloop
       - dependency


### PR DESCRIPTION
fix(mojaloop/#2815): helm chart repo updates are failing due to bitnami's retention policy - https://github.com/mojaloop/project/issues/2815
- updated example-backend chart dependencies repos to use the suggest workaround from the Bitnami issue: https://github.com/bitnami/charts/issues/10539
- Updated CI and Readme to include required Repos
- Cleaned up main readme