### PR TITLE
fix: default.json

### DIFF
--- a/mojaloop/finance-portal/Chart.yaml
+++ b/mojaloop/finance-portal/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.2.4
+version: 4.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.2.4"
+appVersion: "4.2.5"
 dependencies:
   - name: common
     repository: "file://../common"
@@ -63,7 +63,7 @@ dependencies:
     tags:
       - mojaloop
       - reporting-events-processor-svc
-    version: 3.0.0
+    version: 3.0.1
   - name: reporting-hub-bop-role-ui
     condition: reporting-hub-bop-role-ui.enabled
     repository: "file://../reporting-hub-bop-role-ui"

--- a/mojaloop/reporting-events-processor-svc/Chart.yaml
+++ b/mojaloop/reporting-events-processor-svc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Reporting Events Processor
 name: reporting-events-processor-svc
-version: 3.0.0
+version: 3.0.1
 appVersion: "3.0.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png

--- a/mojaloop/reporting-events-processor-svc/templates/config.yaml
+++ b/mojaloop/reporting-events-processor-svc/templates/config.yaml
@@ -10,5 +10,5 @@ metadata:
 data:
 {{- range $fileName, $fileContents := .Values.configFiles }}
   {{ $fileName }}: |
-  {{- include "common.tplvalues.render" ( dict "value" $fileContents "context" $ ) | nindent 4 }}
+  {{- include "common.tplvalues.renderToJson" ( dict "value" $fileContents "context" $ ) | nindent 4 }}
 {{- end }}

--- a/mojaloop/reporting-events-processor-svc/values.yaml
+++ b/mojaloop/reporting-events-processor-svc/values.yaml
@@ -169,18 +169,17 @@ metrics:
       serviceName: reporting-events-processor-svc
 
 configFiles:
-  default.json: |
-    {
+  default.json: {
       "EVENT_STORE_DB": {
-        "HOST": "{{ include "common.backends.reportingEventsDB.host" . }}",
-        "PORT": "{{ include "common.backends.reportingEventsDB.port" . }}",
-        "USER": "{{ include "common.backends.reportingEventsDB.user" . }}",
-        "PASSWORD": "{{ include "common.backends.reportingEventsDB.password" . }}",
-        "DATABASE": "{{ include "common.backends.reportingEventsDB.database" . }}",
+        "HOST": '{{ include "common.backends.reportingEventsDB.host" . }}',
+        "PORT": '{{ include "common.backends.reportingEventsDB.port" . }}',
+        "USER": '{{ include "common.backends.reportingEventsDB.user" . }}',
+        "PASSWORD": '{{ include "common.backends.reportingEventsDB.password" . }}',
+        "DATABASE": '{{ include "common.backends.reportingEventsDB.database" . }}',
         "EVENTS_COLLECTION": "reporting"
       },
       "KAFKA": {
-        "TOPIC_EVENT": "{{ .Values.kafka.topicEvent }}",
+        "TOPIC_EVENT": '{{ .Values.kafka.topicEvent }}',
         "CONSUMER": {
           "EVENT": {
             "config": {
@@ -195,9 +194,9 @@ configFiles:
                 "consumeTimeout": 10
               },
               "rdkafkaConf": {
-                "clientId": "{{ .Values.kafka.clientId }}",
-                "groupId": "{{ .Values.kafka.consumerGroup }}",
-                "metadataBrokerList": "{{ .Values.kafka.host }}:{{ .Values.kafka.port }}",
+                "clientId": '{{ .Values.kafka.clientId }}',
+                "groupId": '{{ .Values.kafka.consumerGroup }}',
+                "metadataBrokerList": '{{ .Values.kafka.host }}:{{ .Values.kafka.port }}',
                 "socketKeepaliveEnable": true,
                 "allowAutoCreateTopics": true,
                 "partitionAssignmentStrategy": "",


### PR DESCRIPTION
reporting-events-processor-svc chart treats the default.json as a string, making it impossible to configure individual properties
